### PR TITLE
Extend the nice checker to include numbers where "69" is INSIDE the number

### DIFF
--- a/TheCountBot.Application/TelegramBotManager.cs
+++ b/TheCountBot.Application/TelegramBotManager.cs
@@ -176,9 +176,14 @@ namespace TheCountBot
             return x > 1000 && x % 1000 == 0;
         }
 
-        private bool IsNice( int x )
-        {
-            return x % 100 == 69;
+        private  bool IsNice( int x ){
+            while ( x >=10 ) {
+                if ( x % 100 == 69 ){
+                    return true;
+                }
+                x /=10;
+            }
+            return false;
         }
 
         private bool IsEvil( int x )


### PR DESCRIPTION

We should celebrate all numbers that have 69 in them... not just ones that end in 69 😄 

---

Tested it online with [this](https://www.tutorialspoint.com/compile_csharp_online.php)

```
using System.IO;
using System;
using System.Collections.Generic;

class Program
{
    static bool IsNice( int x ){
        while ( x >=10) {
            if ( x % 100 == 69){
                return true;
            }
            x /=10;
        }
        return false;
    }
    
    static void Main()
    {
        
        var  testCases = new Dictionary<int, bool>(){
           { 69, true }, 
           { 169, true },
           { 6969, true },
           { 69189, true },
           { 5, false },
           { 10, false },
           { 70, false },
           { 96196, false }
        };
        
        foreach(KeyValuePair<int, bool> testCase in testCases) {
            var result = IsNice(testCase.Key);
            var correct = result == testCase.Value;
            var isCorrect = correct ? "is" : "is NOT!!!";
            var res = String.Format("The test case of {0} {1} correct", testCase.Key, isCorrect);
            Console.WriteLine(res);
        }
    }
}
```