### PR TITLE
Add check to detect if numbers are self describing

### DIFF
--- a/TheCountBot.Application/TelegramBotManager.cs
+++ b/TheCountBot.Application/TelegramBotManager.cs
@@ -191,6 +191,29 @@ namespace TheCountBot
             return x % 1000 == 420;
         }
         
+        private bool IsSelfDescribing( int x )
+        {
+
+             Dictionary<int, int> counter = new Dictionary<int, int>();
+             while ( x > 0 )
+             {
+                 var lastDigit=x%10;
+                 x /= 10;
+                 
+                 if ( ! counter.ContainsKey(lastDigit) ) {
+                     counter[lastDigit]=0;
+                 }
+                 counter[lastDigit]+=1;
+             }
+
+             foreach (KeyValuePair<int, int> pair in counter) {
+                 if (pair.Key != pair.Value) {
+                     return false;
+                 }
+             }
+             return true;
+        }
+        
         private bool IsChaotic()
         {
             return _rng_chaos.Next(0, 250) == 0;
@@ -225,6 +248,10 @@ namespace TheCountBot
             else if ( IsDank(x) )
             {
                 await SendMessageAsync( $"@{user} blaze it!" );
+            }
+            else if ( IsSelfDescribing(x) )
+            {
+                await SendMessageAsync( $"Yo @{user} that number is kinda cool!" );
             }
             else if ( IsChaotic() ) 
             {


### PR DESCRIPTION
Re opening #37 with some tests this time.

You can run this code over [here](https://www.tutorialspoint.com/compile_csharp_online.php)

```
using System.IO;
using System;
using System.Collections.Generic;

class Program
{
    static bool IsCool( int x )
         {

             Dictionary<int, int> counter = new Dictionary<int, int>();
             while ( x > 0 )
             {
                 var lastDigit=x%10;
                 x /= 10;
                 
                 // python has a Counter wouldn't that be nice here...
                 if ( ! counter.ContainsKey(lastDigit) ) {
                     counter[lastDigit]=0;
                 }
                 counter[lastDigit]+=1;
             }

             foreach (KeyValuePair<int, int> pair in counter) {
                 if (pair.Key != pair.Value) {
                     return false;
                 }
             }
             return true;
         }
    
    static void Main()
    {
        
        var  testCases = new Dictionary<int, bool>(){
            
            {1, true},
            {22, true},
            {333, true},
            {212, true},
            {2214444, true},
            {32323, true},
            
            {10, false}, 
            {13333, false},
            {22144404, false},
            
        };
        
        foreach(KeyValuePair<int, bool> testCase in testCases) {
            var result = IsCool(testCase.Key);
            var correct = result == testCase.Value;
            var isCorrect = correct ? "is" : "is NOT!!!";
            var res = String.Format("The test case of {0} {1} correct", testCase.Key, isCorrect);
            Console.WriteLine(res);
        }
    }
}
```